### PR TITLE
Improve CMakeLists.txt so that CMAKE_MODULE_PATH doesn't have to be set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
 endif()
 
 include(cmake/k4PandoraDependencies.cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PandoraSDK_LIBRARY_DIRS}/cmake")
+
 
 ##############################################################################
 # Source Code


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve CMakeLists.txt so that CMAKE_MODULE_PATH doesn't have to be set

ENDRELEASENOTES

Currently it doesn't compile without setting it, see how it's done in spack for example: https://github.com/key4hep/key4hep-spack/blob/release/packages/k4pandora/package.py#L52. This allows to configure it but I think compilation is still broken.